### PR TITLE
Add Stop method for live outputs

### DIFF
--- a/lib/kiss-ffmpeg.js
+++ b/lib/kiss-ffmpeg.js
@@ -27,6 +27,7 @@ class FFmpeg extends EventEmitter {
     this.outputs = []; // array of {url, options}. file maybe 'stdout' to pipe out
     this.global = {}; // key-value pairs of global options
     this.spawnOptions = {}; // spawn options
+    this.proc = null; // instance of child_process.spawn() to send kill signal to
     Object.assign(this, opts);
 
     // # of event listeners
@@ -365,6 +366,8 @@ class FFmpeg extends EventEmitter {
     //   )
     // );
 
+    this.proc = proc;
+
     return proc;
   }
 
@@ -374,6 +377,16 @@ class FFmpeg extends EventEmitter {
    */
   runSync() {
     return FFmpeg.spawnSync(this.parseArgs(), this.spawnOptions);
+  }
+
+  /**
+   * stop running FFmpeg process
+   */
+   stop(){ 
+    if (this.proc) {
+      this.proc.kill("SIGINT");
+      this.proc = null;
+    }
   }
 }
 

--- a/lib/kiss-ffmpeg.js
+++ b/lib/kiss-ffmpeg.js
@@ -172,6 +172,7 @@ class FFmpeg extends EventEmitter {
               "close",
               () => {
                 if (!proc.stdin.writableEnded) proc.stdin.end();
+                this.proc = null;
               }
             ],
             [
@@ -179,6 +180,7 @@ class FFmpeg extends EventEmitter {
               err => {
                 stdioerr = `Input stream error: ${err.message}`;
                 proc.kill("SIGINT");
+                this.proc = null;
               }
             ]
           )
@@ -202,6 +204,7 @@ class FFmpeg extends EventEmitter {
             err => {
               stdioerr = `Output stream error: ${err.message}`;
               proc.kill("SIGINT");
+              this.proc = null;
             }
           ])
         );


### PR DESCRIPTION
instances where a live steam input/output is involved, requires the process be sent `SIGINT` in order to destroy the spawned process. 